### PR TITLE
fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 import React from 'react'
-import reactDom from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import App from './src/App'
 
-reactDom.render(<App />, document.getElementById('root'))
+const container = document.getElementById('root')
+const root = createRoot(container)
+root.render(<App />)


### PR DESCRIPTION
ReactDOM.render is no longer supported in React 18. Use createRoot instead.